### PR TITLE
Fix network creation 

### DIFF
--- a/src/api/network/mod.rs
+++ b/src/api/network/mod.rs
@@ -47,7 +47,7 @@ impl<'docker> Network<'docker> {
 impl<'docker> Networks<'docker> {
     impl_api_ep! { __: Network, resp
         List -> "/networks"
-        Create -> "/network/create", resp.id
+        Create -> "/networks/create", resp.id
         Prune -> "/networks/prune"
     }
 }


### PR DESCRIPTION
## What did you implement:

Fixed a typo in network/mod.rs which bugged network creation and returned
`Fault { code: 404, message: "page not found" }'`


## How did you verify your change:

Manually tested it.
