### PR TITLE
Use proper lifetime 'docker in create

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -507,7 +507,7 @@ macro_rules! impl_api_ep {
         api_doc! { $base => Create
         #[doc = concat!("Create a new ", stringify!($base), ".")]
         |
-        pub async fn create(&self, opts: &[< $base CreateOpts >]) -> Result<[< $base >]<'_>> {
+        pub async fn create(&self, opts: &[< $base CreateOpts >]) -> Result<[< $base >]<'docker>> {
             self.docker.post_json(&$ep, Payload::Json(opts.serialize()?)).await
             .map(|$resp: [< $base CreateInfo >]| [< $base >]::new(self.docker, $($extra)*))
         }}


### PR DESCRIPTION
## What did you implement:

This PR corrects the lifetime parameter of the `create` method generated by the `impl_api_ep!` macro. The generated structs usually have a `'docker` lifetime as they reference a core `Docker` object. The generated create method however used an anonymous lifetime which made it impossible to pass around objects created by `create`.

## How did you verify your change:

Minimal example from one of my private projects using networks as entity:

Cargo.toml
```
...

[dependencies]
docker-api = "0.8.0"
futures = { version = "0.3.19", default-features = false, features = ["std"] }
tokio = { version = "1.9.0", features = ["rt", "macros"] }
```

src/main.rs
```rust
use std::{ops::Deref, pin::Pin};

use docker_api::*;
use docker_api::network::NetworkCreateOpts;
use futures::Future;

#[tokio::main]
async fn main() {
    let docker = Docker::new("unix:///var/run/docker.sock").unwrap();
    let network_opts = NetworkCreateOpts::builder("network_name").build();
    with_network(&docker, &network_opts, |network| -> Pin<Box<dyn Future<Output = std::result::Result<(), Error>>>> {
        Box::pin(async move {
            println!("Hello!");
            Ok(())
        })
    }).await.unwrap();
}

/// Wrapper around docker_api::Network which implements Clone
pub struct Network<'d> {
    docker: &'d Docker,
    network: docker_api::Network<'d>,
}

impl<'d> Network<'d> {
    pub fn new(docker: &'d Docker, network: docker_api::Network<'d>) -> Self {
        Self { docker, network }
    }
}

impl<'d> Clone for Network<'d> {
    fn clone(&self) -> Self {
        Self {
            docker: self.docker,
            network: docker_api::Network::new(self.docker, self.network.id()),
        }
    }
}

impl<'d> Deref for Network<'d> {
    type Target = docker_api::Network<'d>;

    fn deref(&self) -> &Self::Target {
        &self.network
    }
}

async fn with_network<'d, F, R, E>(docker: &'d Docker, opts: &NetworkCreateOpts, op: F) -> std::result::Result<R, E>
where
    F: FnOnce(Network<'d>) -> Pin<Box<dyn Future<Output = std::result::Result<R, E>> + 'd>>,
    E: From<Error>,
{
    let networks = docker.networks();
    let network = Network::<'d>::new(
        docker,
        networks.create(opts).await?,
    );
    let result = op(network.clone()).await;
    network.delete().await?;
    result
}
```

Compiling this example fails:
```
error[E0597]: `networks` does not live long enough
  --> src/main.rs:57:9
   |
47 |   async fn with_network<'d, F, R, E>(docker: &'d Docker, opts: &NetworkCreateOpts, op: F) -> std::result::Result<R, E>
   |                         -- lifetime `'d` defined here
...
55 |       let network = Network::<'d>::new(
   |  ___________________-
56 | |         docker,
57 | |         networks.create(opts).await?,
   | |         ^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
58 | |     );
   | |_____- argument requires that `networks` is borrowed for `'d`
...
62 |   }
   |   - `networks` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
```

Using this patch, the compilation works.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Fixed a bug that caused lifetime issues when passing around objects created by the docker API, e.g. networks.