### PR TITLE
Remove 'docker lifetime from the API and make it fully owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.9.0
 - Fix `ContainersPruneInfo` deserialization
 - Logs endpoint now correctly returns `TtyChunk` instead of `Bytes`
+- *BREAKING* All API structs no longer have a `'docker` lifetime. This change makes it easier to create self working objects without the lifetime hell and according to
+  hyper client documentation it is cheap to clone and cloning is the recommended way to share a client.
 
 # 0.8.0
 - Make `ContainerInfo::state` and `ContainerSummary::state` strongly typed.

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -85,7 +85,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match opts.subcmd {
         Cmd::Attach { id } => {
-            let tty_multiplexer = docker.containers().get(&id).attach().await?;
+            let container = docker.containers().get(&id);
+            let tty_multiplexer = container.attach().await?;
 
             let (mut reader, _writer) = tty_multiplexer.split();
 

--- a/examples/exec.rs
+++ b/examples/exec.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .attach_stderr(true)
                 .build();
 
-            let exec = Exec::create(&docker, &container, &opts).await?;
+            let exec = Exec::create(docker, &container, &opts).await?;
 
             println!("{:#?}", exec.inspect().await?);
 
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             height,
         } => {
             use docker_api::api::ExecResizeOpts;
-            let exec = Exec::get(&docker, &exec);
+            let exec = Exec::get(docker, &exec);
 
             // Resize its window with given parameters
             let resize_opts = ExecResizeOpts::builder()

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -78,7 +78,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             use docker_api::api::BuildOpts;
             let options = BuildOpts::builder(path).tag(tag).build();
 
-            let mut stream = docker.images().build(&options);
+            let images = docker.images();
+            let mut stream = images.build(&options);
             while let Some(build_result) = stream.next().await {
                 match build_result {
                     Ok(output) => println!("{:?}", output),
@@ -130,7 +131,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let reader = Box::from(f);
 
-            let mut stream = docker.images().import(reader);
+            let images = docker.images();
+            let mut stream = images.import(reader);
 
             while let Some(import_result) = stream.next().await {
                 match import_result {
@@ -183,8 +185,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 PullOpts::builder().image(image).build()
             };
-
-            let mut stream = docker.images().pull(&opts);
+            let images = docker.images();
+            let mut stream = images.pull(&opts);
 
             while let Some(pull_result) = stream.next().await {
                 match pull_result {
@@ -212,7 +214,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let tag_opts = TagOpts::builder().repo(repo).tag(tag).build();
 
-            let image = Image::new(&docker, name);
+            let image = Image::new(docker, name);
 
             if let Err(e) = image.tag(&tag_opts).await {
                 eprintln!("Error: {}", e)

--- a/examples/service.rs
+++ b/examples/service.rs
@@ -78,10 +78,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             use docker_api::api::LogsOpts;
             use futures::StreamExt;
 
-            let logs_stream = docker
-                .services()
-                .get(&service)
-                .logs(&LogsOpts::builder().stdout(stdout).stderr(stderr).build());
+            let service = docker.services().get(&service);
+            let logs_stream =
+                service.logs(&LogsOpts::builder().stdout(stdout).stderr(stderr).build());
 
             let logs: Vec<_> = logs_stream
                 .map(|chunk| match chunk {

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -6,7 +6,7 @@ use crate::{conn::Payload, Result};
 
 impl_api_ty!(Config => name);
 
-impl<'docker> Config<'docker> {
+impl Config {
     impl_api_ep! { cfg: Config, resp
         Inspect -> &format!("/configs/{}", cfg.name)
         Delete -> &format!("/configs/{}", cfg.name)
@@ -15,7 +15,7 @@ impl<'docker> Config<'docker> {
     // TODO: add Config::update
 }
 
-impl<'docker> Configs<'docker> {
+impl Configs {
     impl_api_ep! { __: Config, resp
         List -> "/configs"
         Create -> "/configs/create", resp.id

--- a/src/api/network/mod.rs
+++ b/src/api/network/mod.rs
@@ -10,7 +10,7 @@ use crate::{conn::Payload, Result};
 
 impl_api_ty!(Network => id);
 
-impl<'docker> Network<'docker> {
+impl Network {
     impl_api_ep! { net: Network, resp
         Inspect -> &format!("/networks/{}", net.id)
         Delete -> &format!("/networks/{}", net.id)
@@ -42,7 +42,7 @@ impl<'docker> Network<'docker> {
     }}
 }
 
-impl<'docker> Networks<'docker> {
+impl Networks {
     impl_api_ep! { __: Network, resp
         List -> "/networks"
         Create -> "/networks/create", resp.id

--- a/src/api/node/mod.rs
+++ b/src/api/node/mod.rs
@@ -15,7 +15,7 @@ impl_api_ty!(Node => name);
 
 type Void = ();
 
-impl<'docker> Node<'docker> {
+impl Node {
     impl_api_ep! {node: Node, resp
         Inspect -> &format!("/nodes/{}", node.name)
         ForceDelete -> &format!("/nodes/{}", node.name), Void
@@ -39,7 +39,7 @@ impl<'docker> Node<'docker> {
     }}
 }
 
-impl<'docker> Nodes<'docker> {
+impl Nodes {
     impl_api_ep! {node: Node, resp
         List -> "/nodes"
     }

--- a/src/api/plugin/mod.rs
+++ b/src/api/plugin/mod.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 impl_api_ty!(Plugin => name);
 
-impl<'docker> Plugin<'docker> {
+impl Plugin {
     impl_api_ep! {plug: Plugin, resp
         Inspect -> &format!("/plugins/{}/json", plug.name)
         ForceDelete -> &format!("/plugins/{}", plug.name), PluginInfo
@@ -74,7 +74,7 @@ impl<'docker> Plugin<'docker> {
     }}
 }
 
-impl<'docker> Plugins<'docker> {
+impl Plugins {
     impl_api_ep! {plug: Plugin, resp
         List -> "/plugins"
     }

--- a/src/api/secret.rs
+++ b/src/api/secret.rs
@@ -5,7 +5,7 @@ use crate::{conn::Payload, Result};
 
 impl_api_ty!(Secret => name);
 
-impl<'docker> Secret<'docker> {
+impl Secret {
     impl_api_ep! { secret: Secret, resp
         Inspect -> &format!("/secrets/{}", secret.name)
         Delete -> &format!("/secrets/{}", secret.name)
@@ -13,7 +13,7 @@ impl<'docker> Secret<'docker> {
     // TODO: add Secret::update
 }
 
-impl<'docker> Secrets<'docker> {
+impl Secrets {
     impl_api_ep! { __: Secret, resp
         List -> "/secrets"
         Create -> "/secrets/create", resp.id

--- a/src/api/service/mod.rs
+++ b/src/api/service/mod.rs
@@ -10,10 +10,11 @@ use crate::{
     conn::{Headers, Payload, AUTH_HEADER},
     Result,
 };
+use containers_api_conn::tty::TtyChunk;
 
 impl_api_ty!(Service => name);
 
-impl<'docker> Service<'docker> {
+impl Service {
     api_doc! { Service => Create
     /// Creates a new service from ServiceOpts.
     |
@@ -37,7 +38,7 @@ impl<'docker> Service<'docker> {
     }
 }
 
-impl<'docker> Services<'docker> {
+impl Services {
     impl_api_ep! { svc: Service, resp
         List -> "/services"
     }

--- a/src/api/swarm/mod.rs
+++ b/src/api/swarm/mod.rs
@@ -10,13 +10,13 @@ use crate::{conn::Payload, Docker, Result};
 
 api_doc! { Swarm
 |
-pub struct Swarm<'docker> {
-    docker: &'docker Docker,
+pub struct Swarm {
+    docker: Docker,
 }
 }
 
-impl<'docker> Swarm<'docker> {
-    pub fn new(docker: &'docker Docker) -> Self {
+impl Swarm {
+    pub fn new(docker: Docker) -> Self {
         Self { docker }
     }
 

--- a/src/api/task.rs
+++ b/src/api/task.rs
@@ -3,17 +3,18 @@
 //! Swarm mode must be enabled for these endpoints to work.
 
 use crate::Result;
+use containers_api_conn::tty::TtyChunk;
 
 impl_api_ty!(Task => id);
 
-impl<'docker> Task<'docker> {
+impl Task {
     impl_api_ep! { task: Task, resp
         Inspect -> &format!("/tasks/{}", task.id)
         Logs -> &format!("/tasks/{}/logs", task.id)
     }
 }
 
-impl<'docker> Tasks<'docker> {
+impl Tasks {
     impl_api_ep! { task: Task, resp
         List -> "/tasks"
     }

--- a/src/api/volume/mod.rs
+++ b/src/api/volume/mod.rs
@@ -9,14 +9,14 @@ use crate::{conn::Payload, Result};
 
 impl_api_ty!(Volume => name);
 
-impl<'docker> Volume<'docker> {
+impl Volume {
     impl_api_ep! {vol: Volume, resp
         Inspect -> &format!("/volumes/{}", vol.name)
         Delete -> &format!("/volumes/{}", vol.name)
     }
 }
 
-impl<'docker> Volumes<'docker> {
+impl Volumes {
     impl_api_ep! {__: Volume, resp
         Create -> "/volumes/create", resp.name
         List -> "/volumes", VolumesInfo

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -199,23 +199,23 @@ impl Docker {
     }
 
     /// Exports an interface for interacting with Docker images
-    pub fn images(&'_ self) -> Images<'_> {
-        Images::new(self)
+    pub fn images(&'_ self) -> Images {
+        Images::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker containers
-    pub fn containers(&'_ self) -> Containers<'_> {
-        Containers::new(self)
+    pub fn containers(&'_ self) -> Containers {
+        Containers::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker networks
-    pub fn networks(&'_ self) -> Networks<'_> {
-        Networks::new(self)
+    pub fn networks(&'_ self) -> Networks {
+        Networks::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker volumes
-    pub fn volumes(&'_ self) -> Volumes<'_> {
-        Volumes::new(self)
+    pub fn volumes(&'_ self) -> Volumes {
+        Volumes::new(self.clone())
     }
 
     /// Verifies the API version returned by the server and adjusts the version used by this client
@@ -503,38 +503,38 @@ impl Docker {
 #[cfg(feature = "swarm")]
 impl Docker {
     /// Exports an interface for interacting with Docker services.
-    pub fn services(&'_ self) -> Services<'_> {
-        Services::new(self)
+    pub fn services(&'_ self) -> Services {
+        Services::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker configs.
-    pub fn configs(&'_ self) -> Configs<'_> {
-        Configs::new(self)
+    pub fn configs(&'_ self) -> Configs {
+        Configs::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker tasks.
-    pub fn tasks(&'_ self) -> Tasks<'_> {
-        Tasks::new(self)
+    pub fn tasks(&'_ self) -> Tasks {
+        Tasks::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker secrets.
-    pub fn secrets(&'_ self) -> Secrets<'_> {
-        Secrets::new(self)
+    pub fn secrets(&'_ self) -> Secrets {
+        Secrets::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker swarm.
-    pub fn swarm(&'_ self) -> Swarm<'_> {
-        Swarm::new(self)
+    pub fn swarm(&'_ self) -> Swarm {
+        Swarm::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker nodes.
-    pub fn nodes(&'_ self) -> Nodes<'_> {
-        Nodes::new(self)
+    pub fn nodes(&'_ self) -> Nodes {
+        Nodes::new(self.clone())
     }
 
     /// Exports an interface for interacting with Docker plugins.
-    pub fn plugins(&'_ self) -> Plugins<'_> {
-        Plugins::new(self)
+    pub fn plugins(&'_ self) -> Plugins {
+        Plugins::new(self.clone())
     }
 }
 


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

All API structs no longer have a `'docker` lifetime. This change makes it easier to create self working objects without the lifetime hell and according to hyper client [documentation](https://docs.rs/hyper/latest/hyper/client/struct.Client.html) it is cheap to clone and cloning is the recommended way to share a client.
