### PR TITLE
Fix: PortMap can be null

### DIFF
--- a/docker-api-stubs/lib/src/models.rs
+++ b/docker-api-stubs/lib/src/models.rs
@@ -4003,7 +4003,7 @@ pub struct PortBinding {
 ///
 /// If a container's port is mapped for multiple protocols, separate entries
 /// are added to the mapping table.
-pub type PortMap = HashMap<String, Vec<PortBinding>>;
+pub type PortMap = HashMap<String, Option<Vec<PortBinding>>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PortTypeInlineItem {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Fixed a type in `lib/src/models.rs`. The value of the PortMap could be null. I changed `Vec<PortBinding>` to `Option<Vec<PortBinding>>` to avoid an error.

<!--
If this closes an open issue please replace xxx below with the issue number
Closes: #xxx
-->

## How did you verify your change:

Manually tested it.
