### PR TITLE
Fix Container::attach output when TTY is enabled on container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#
+- Fix Container::attach output when TTY is enabled on container
+
 # 0.12.0
 - Fix some integer fields that could be negative but previously were a usize like `ImageSummary::containers`
 - Fix deserialization of nullable map types like `ImageSummary::labels`


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #43 

## How did you verify your change:

Ran provided example localy with custom image and got output even with TTY enabled.

```
❯ cargo r
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/docktest`
Created container: 653c288ad5082417038a32343b6bea2868f2351c9e821a69a870ebac4b0984a6
Starting container...
Started container.
StdOut([121, 111, 117, 114, 32, 109, 117, 109, 13, 10])
StdOut([121, 111, 117, 114, 32, 109, 117, 109, 13, 10])
❯ cat src/main.rs  | grep tty
                .tty(true)
```
