### PR TITLE
Add support for multithreaded compression when building image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #
 - Fix Container::attach output when TTY is enabled on container
+- Add `Image::build_par` that uses multithreaded compression algorithm for creating context directory archive. This method is behind `par-compression` feature flag.
 
 # 0.12.0
 - Fix some integer fields that could be negative but previously were a usize like `ImageSummary::containers`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 readme = "README.md"
 
 [dependencies]
-containers-api = "0.7"
-#containers-api = { git = "https://github.com/vv9k/containers-api" }
+#containers-api = "0.7"
+containers-api = { git = "https://github.com/vv9k/containers-api" }
 
 docker-api-stubs = "0.4"
 #docker-api-stubs = { path = "./docker-api-stubs/lib" }
@@ -62,6 +62,7 @@ nix = "0.25"
 default = ["containers-api/chrono", "chrono"]
 tls = ["containers-api/tls"]
 vendored-ssl = ["tls", "containers-api/vendored-ssl"]
+par-compress = ["containers-api/par-compress"]
 swarm = []
 
 


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Added a separate `Image::build_par` method that uses multithreaded compression for creating archive with build context directory. This significantly speeds up the execution on very large directories like this repository when cloned (mostly cause due to amount of git files).
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #39

## How did you verify your change:

## What (if anything) would need to be called out in the CHANGELOG for the next release: