### PR TITLE
Add more `ContainerCreateOptsBuilder` parameters

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -331,11 +331,17 @@ impl ToString for PublishPort {
     }
 }
 
+/// IPC sharing mode for the container.
 pub enum IpcMode {
+    /// "none": own private IPC namespace, with /dev/shm not mounted
     None,
+    /// "private": own private IPC namespace
     Private,
+    /// "shareable": own private IPC namespace, with a possibility to share it with other containers
     Shareable,
+    /// "container:<name|id>": join another (shareable) container's IPC namespace
     Container(String),
+    /// "host": use the host system's IPC namespace
     Host,
 }
 
@@ -351,8 +357,11 @@ impl ToString for IpcMode {
     }
 }
 
+/// PID (Process) Namespace mode for the container.
 pub enum PidMode {
+    /// "container:<name|id>": joins another container's PID namespace
     Container(String),
+    /// "host": use the host's PID namespace inside the container
     Host,
 }
 

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -547,6 +547,26 @@ impl ContainerCreateOptsBuilder {
             params: self.params.clone(),
         }
     }
+
+    impl_str_field!(
+    /// The hostname to use for the container, as a valid RFC 1123 hostname.
+        hostname => "Hostname"
+    );
+
+    impl_str_field!(
+    /// The domain name to use for the container.
+        domainname => "Domainname"
+    );
+
+    impl_str_field!(
+    /// IPC sharing mode for the container. Default is "private" or "shareable", depending on daemon version.
+        ipc => "HostConfig.IpcMode"
+    );
+
+    impl_str_field!(
+    /// Set the PID (Process) Namespace mode for the container.
+        pid => "HostConfig.PidMode"
+    );
 }
 
 impl_opts_builder!(url => ContainerRemove);

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -2,8 +2,8 @@ use crate::models::Labels;
 use crate::opts::ImageName;
 use containers_api::opts::{Filter, FilterItem};
 use containers_api::{
-    impl_field, impl_filter_func, impl_map_field, impl_opts_builder, impl_str_field,
-    impl_url_bool_field, impl_url_str_field, impl_vec_field,
+    impl_field, impl_filter_func, impl_map_field, impl_opts_builder, impl_str_enum_field,
+    impl_str_field, impl_url_bool_field, impl_url_str_field, impl_vec_field,
 };
 
 use std::{
@@ -331,6 +331,40 @@ impl ToString for PublishPort {
     }
 }
 
+pub enum IpcMode {
+    None,
+    Private,
+    Shareable,
+    Container(String),
+    Host,
+}
+
+impl ToString for IpcMode {
+    fn to_string(&self) -> String {
+        match &self {
+            IpcMode::None => String::from("none"),
+            IpcMode::Private => String::from("private"),
+            IpcMode::Shareable => String::from("shareable"),
+            IpcMode::Container(id) => format!("container:{}", id),
+            IpcMode::Host => String::from("host"),
+        }
+    }
+}
+
+pub enum PidMode {
+    Container(String),
+    Host,
+}
+
+impl ToString for PidMode {
+    fn to_string(&self) -> String {
+        match &self {
+            PidMode::Container(id) => format!("container:{}", id),
+            PidMode::Host => String::from("host"),
+        }
+    }
+}
+
 impl ContainerCreateOptsBuilder {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
@@ -558,14 +592,14 @@ impl ContainerCreateOptsBuilder {
         domainname => "Domainname"
     );
 
-    impl_str_field!(
+    impl_str_enum_field!(
     /// IPC sharing mode for the container. Default is "private" or "shareable", depending on daemon version.
-        ipc => "HostConfig.IpcMode"
+        ipc: IpcMode => "HostConfig.IpcMode"
     );
 
-    impl_str_field!(
+    impl_str_enum_field!(
     /// Set the PID (Process) Namespace mode for the container.
-        pid => "HostConfig.PidMode"
+        pid: PidMode => "HostConfig.PidMode"
     );
 }
 


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

I added the parameters `Hostname`,`Domainname`,`IpcMode` and `PidMode` to `ContainerCreateOptsBuilder`, needed for container-host integration in my use-case, following the Docker API documentation.

## How did you verify your change:

I created a container with the new parameters and checked the behavior using `docker inspect`

```rust
let opts = ContainerCreateOpts::builder()
    .name("opt-test")
    .hostname("host")
    .domainname("host")
    .ipc("host")
    .pid("host")
    .build();
```
```sh
$ docker inspect "opt-test" | grep "IpcMode"
            "IpcMode": "host",
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:
Add parameters `Hostname`,`Domainname`,`IpcMode` and `PidMode` to `ContainerCreateOptsBuilder`