### PR TITLE
Rework exec to handle stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 - Add `ContainerCreateOptsBuilder::network_config`
 - `Docker` initializers like `new`, `tcp`, `unix`, `tls` now create an unversioned connector that will use the server's latest version instead of setting it to `LATEST_API_VERSION`.
   This means that by default this crate will be easier to use with older versions of Docker.
+- `Exec::start` and `Container::exec` now take `ExecStartOpts` options as additional parameter
+- Add missing `attach_stdin` to `ExecCreateOpts`
+- `Exec::start` and `Container::exec` signature changed. It is now async and returns a result with `tty::Multiplexer` (same as attach) 
+  so that it can handle writing to STDIN.
 
 # 0.13.0
 - Fix Container::attach output when TTY is enabled on container

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -254,7 +254,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .attach_stderr(true)
                 .build();
 
-            while let Some(exec_result) = docker.containers().get(&id).exec(&options).next().await {
+            let container = docker.containers().get(&id);
+            let mut stream = container
+                .exec(&options, &Default::default())
+                .await
+                .expect("exec stream");
+            while let Some(exec_result) = stream.next().await {
                 match exec_result {
                     Ok(chunk) => print_chunk(chunk),
                     Err(e) => eprintln!("Error: {e}"),

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -86,7 +86,7 @@ impl Exec {
         opts: &ExecStartOpts,
     ) -> Result<tty::Multiplexer<'docker>> {
         let endpoint = format!("/exec/{}/start", id);
-        let inspect_data = Self::inspect_impl(&docker, &id).await?;
+        let inspect_data = Self::inspect_impl(docker, id).await?;
         let is_tty = inspect_data
             .process_config
             .and_then(|c| c.tty)
@@ -115,9 +115,9 @@ impl Exec {
         start_opts: &ExecStartOpts,
     ) -> Result<tty::Multiplexer<'docker>> {
         let container_id = container_id.as_ref();
-        let id = Self::create_impl(docker.clone(), container_id, &create_opts).await?;
+        let id = Self::create_impl(docker.clone(), container_id, create_opts).await?;
 
-        Self::start_impl(docker, id.as_ref(), &start_opts).await
+        Self::start_impl(docker, id.as_ref(), start_opts).await
     }
 
     api_doc! { Exec => Resize

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -1,16 +1,12 @@
 //! Run new commands inside running containers.
 
-use futures_util::{
-    stream::{Stream, TryStreamExt},
-    TryFutureExt,
-};
 use hyper::Body;
 
 use crate::{
     conn::{tty, Headers, Payload},
     models,
-    opts::{ExecCreateOpts, ExecResizeOpts},
-    Docker, Result,
+    opts::{ExecCreateOpts, ExecResizeOpts, ExecStartOpts},
+    stream, Docker, Result,
 };
 
 api_doc! { Exec
@@ -29,101 +25,6 @@ impl Exec {
         }
     }
 
-    impl_api_ep! {exec: Exec, resp
-        Inspect -> &format!("/exec/{}/json", exec.id), models::ExecInspect200Response
-    }
-
-    api_doc! { Exec => Create
-    |
-    /// Creates a new exec instance that will be executed in a container with id == container_id.
-    pub async fn create<C>(
-        docker: Docker,
-        container_id: C,
-        opts: &ExecCreateOpts,
-    ) -> Result<Exec>
-    where
-        C: AsRef<str>,
-    {
-        #[derive(serde::Deserialize)]
-        #[serde(rename_all = "PascalCase")]
-        struct Response {
-            id: String,
-        }
-
-        docker
-            .post_json(
-                &format!("/containers/{}/exec", container_id.as_ref()),
-                Payload::Json(opts.serialize_vec()?),
-                Headers::none(),
-            )
-            .await
-            .map(|resp: Response| Exec::new(docker, resp.id))
-    }}
-
-    // This exists for Container::exec()
-    //
-    // We need to combine `Exec::create` and `Exec::start` into one method because otherwise you
-    // needlessly tie the Stream to the lifetime of `container_id` and `opts`. This is because
-    // `Exec::create` is async so it must occur inside of the `async move` block. However, this
-    // means that `container_id` and `opts` are both expected to be alive in the returned stream
-    // because we can't do the work of creating an endpoint from `container_id` or serializing
-    // `opts`. By doing this work outside of the stream, we get owned values that we can then move
-    // into the stream and have the lifetimes work out as you would expect.
-    //
-    // Yes, it is sad that we can't do the easy method and thus have some duplicated code.
-    pub(crate) fn create_and_start<'docker, C>(
-        docker: &'docker Docker,
-        container_id: C,
-        opts: &ExecCreateOpts,
-    ) -> impl Stream<Item = crate::conn::Result<tty::TtyChunk>> + Unpin + 'docker
-    where
-        C: AsRef<str>,
-    {
-        #[derive(serde::Deserialize)]
-        #[serde(rename_all = "PascalCase")]
-        struct Response {
-            id: String,
-        }
-
-        // To not tie the lifetime of `opts` to the stream, we do the serializing work outside of
-        // the stream. But for backwards compatability, we have to return the error inside of the
-        // stream.
-        let body_result = opts.serialize();
-
-        // To not tie the lifetime of `container_id` to the stream, we convert it to an (owned)
-        // endpoint outside of the stream.
-        let container_endpoint = format!("/containers/{}/exec", container_id.as_ref());
-
-        Box::pin(
-            async move {
-                let exec_id = docker
-                    .post_json(
-                        &container_endpoint,
-                        Payload::Json(
-                            body_result.map_err(|e| crate::conn::Error::Any(Box::new(e)))?,
-                        ),
-                        Headers::none(),
-                    )
-                    .await
-                    .map(|resp: Response| resp.id)
-                    .map_err(|e| crate::conn::Error::Any(Box::new(e)))?;
-
-                let stream = Box::pin(
-                    docker
-                        .post_stream(
-                            format!("/exec/{exec_id}/start"),
-                            Payload::Json("{}"),
-                            Headers::none(),
-                        )
-                        .map_err(|e| crate::conn::Error::Any(Box::new(e))),
-                );
-
-                Ok(tty::decode(stream))
-            }
-            .try_flatten_stream(),
-        )
-    }
-
     /// Get a reference to a set of operations available to an already created exec instance.
     ///
     /// It's in callers responsibility to ensure that exec instance with specified id actually
@@ -133,29 +34,91 @@ impl Exec {
         Exec::new(docker, id)
     }
 
+    api_doc! { Exec => Inspect
+    |
+    /// Inspect this Exec instance
+    pub async fn inspect(&self) -> Result<models::ExecInspect200Response> {
+        Self::inspect_impl(&self.docker, self.id.as_ref()).await
+    }}
+
+    async fn inspect_impl(docker: &Docker, id: &str) -> Result<models::ExecInspect200Response> {
+        docker.get_json(&format!("/exec/{id}/json")).await
+    }
+
+    async fn create_impl(
+        docker: Docker,
+        container_id: &str,
+        opts: &ExecCreateOpts,
+    ) -> Result<crate::Id> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct Response {
+            id: String,
+        }
+
+        docker
+            .post_json(
+                &format!("/containers/{}/exec", container_id),
+                Payload::Json(opts.serialize_vec()?),
+                Headers::none(),
+            )
+            .await
+            .map(|resp: Response| resp.id.into())
+    }
+
+    api_doc! { Exec => Create
+    |
+    /// Creates a new exec instance that will be executed in a container with id == container_id.
+    pub async fn create(
+        docker: Docker,
+        container_id: impl AsRef<str>,
+        opts: &ExecCreateOpts,
+    ) -> Result<Exec>
+    {
+        Self::create_impl(docker.clone(), container_id.as_ref(), opts)
+        .await
+            .map(|id| Exec::new(docker, id))
+    }}
+
+    async fn start_impl<'docker>(
+        docker: &'docker Docker,
+        id: &str,
+        opts: &ExecStartOpts,
+    ) -> Result<tty::Multiplexer<'docker>> {
+        let endpoint = format!("/exec/{}/start", id);
+        let inspect_data = Self::inspect_impl(&docker, &id).await?;
+        let is_tty = inspect_data
+            .process_config
+            .and_then(|c| c.tty)
+            .unwrap_or_default();
+
+        stream::attach(
+            docker,
+            endpoint,
+            Payload::Json(opts.serialize_vec()?.into()),
+            is_tty,
+        )
+        .await
+    }
+
     api_doc! { Exec => Start
     |
     /// Starts this exec instance returning a multiplexed tty stream.
-    pub fn start(&self) -> impl Stream<Item = crate::conn::Result<tty::TtyChunk>> + '_ {
-        // We must take ownership of the docker reference to not needlessly tie the stream to the
-        // lifetime of `self`.
-        let docker = &self.docker;
-        // We convert `self.id` into the (owned) endpoint outside of the stream to not needlessly
-        // tie the stream to the lifetime of `self`.
-        let endpoint = format!("/exec/{}/start", &self.id);
-        Box::pin(
-            async move {
-                let stream = Box::pin(
-                    docker
-                        .post_stream(endpoint, Payload::Json("{}"), Headers::none())
-                        .map_err(|e| crate::conn::Error::Any(Box::new(e))),
-                );
-
-                Ok(tty::decode(stream))
-            }
-            .try_flatten_stream(),
-        )
+    pub async fn start(&self, opts: &ExecStartOpts) -> Result<tty::Multiplexer<'_>> {
+        Self::start_impl(&self.docker, self.id.as_ref(), opts).await
     }}
+
+    pub(crate) async fn create_and_start<'docker>(
+        docker: &'docker Docker,
+        container_id: impl AsRef<str>,
+        create_opts: &ExecCreateOpts,
+        start_opts: &ExecStartOpts,
+    ) -> Result<tty::Multiplexer<'docker>> {
+        let container_id = container_id.as_ref();
+        let id = Self::create_impl(docker.clone(), container_id, &create_opts).await?;
+
+        Self::start_impl(docker, id.as_ref(), &start_opts).await
+    }
 
     api_doc! { Exec => Resize
     |

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -330,6 +330,7 @@ impl Docker {
         self.client.head(self.make_endpoint(endpoint)).await
     }
 
+    #[allow(dead_code)]
     /// Send a streaming post request.
     ///
     /// Use stream_post_into_values if the endpoint returns JSON values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod builder;
 
 pub mod api;
 pub mod models;
+mod stream;
 pub mod conn {
     //! Connection related items
     pub(crate) use containers_api::conn::*;

--- a/src/opts/exec.rs
+++ b/src/opts/exec.rs
@@ -40,6 +40,11 @@ impl ExecCreateOptsBuilder {
         attach_stderr: bool => "AttachStderr"
     );
 
+    impl_field!(
+        /// Attach to stdin of the exec command.
+        attach_stdin: bool => "AttachStdin"
+    );
+
     impl_str_field!(
         /// Override the key sequence for detaching a container. Format is a single
         /// character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _.

--- a/src/opts/exec.rs
+++ b/src/opts/exec.rs
@@ -84,3 +84,22 @@ impl ExecResizeOptsBuilder {
     impl_field!(height: u64 => "Height");
     impl_field!(width: u64 => "Width");
 }
+
+impl_opts_builder!(json => ExecStart);
+
+impl ExecStartOptsBuilder {
+    impl_field!(
+        /// Detach from the command.
+        detach: bool => "Detach"
+    );
+
+    impl_field!(
+        /// Allocate a pseudo-TTY.
+        tty: bool => "Tty"
+    );
+
+    impl_field!(
+        /// Initial console size
+        console_size: ConsoleSize => "ConsoleSize"
+    );
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,16 +6,16 @@ use hyper::Body;
 use crate::{Docker, Result};
 
 /// Attaches a multiplexed TCP stream to the container that can be used to read Stdout, Stderr and write Stdin.
-async fn attach_raw<'docker>(
-    docker: &'docker Docker,
+async fn attach_raw(
+    docker: &Docker,
     endpoint: String,
     payload: Payload<Body>,
-) -> Result<impl AsyncRead + AsyncWrite + Send + 'docker> {
+) -> Result<impl AsyncRead + AsyncWrite + Send + '_> {
     docker.post_upgrade_stream(endpoint, payload).await
 }
 
-pub async fn attach<'docker>(
-    docker: &'docker Docker,
+pub async fn attach(
+    docker: &Docker,
     endpoint: String,
     payload: Payload<Body>,
     is_tty: bool,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,30 @@
+use containers_api::conn::tty;
+use containers_api::conn::Payload;
+use futures_util::{AsyncRead, AsyncWrite};
+use hyper::Body;
+
+use crate::{Docker, Result};
+
+/// Attaches a multiplexed TCP stream to the container that can be used to read Stdout, Stderr and write Stdin.
+async fn attach_raw<'docker>(
+    docker: &'docker Docker,
+    endpoint: String,
+    payload: Payload<Body>,
+) -> Result<impl AsyncRead + AsyncWrite + Send + 'docker> {
+    docker.post_upgrade_stream(endpoint, payload).await
+}
+
+pub async fn attach<'docker>(
+    docker: &'docker Docker,
+    endpoint: String,
+    payload: Payload<Body>,
+    is_tty: bool,
+) -> Result<tty::Multiplexer<'_>> {
+    attach_raw(docker, endpoint, payload).await.map(|s| {
+        if is_tty {
+            tty::Multiplexer::new(s, tty::decode_raw)
+        } else {
+            tty::Multiplexer::new(s, tty::decode_chunk)
+        }
+    })
+}

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -252,27 +252,35 @@ async fn container_exec() {
 
     let _ = container.start().await;
 
-    let mut exec_stream = container.exec(
-        &ExecCreateOpts::builder()
-            .attach_stderr(true)
-            .attach_stdout(true)
-            .command([
-                "bash",
-                "-c",
-                "mkdir /tmp/test123 && echo 1234 >> /tmp/test123/testfile",
-            ])
-            .build(),
-    );
+    let mut exec_stream = container
+        .exec(
+            &ExecCreateOpts::builder()
+                .attach_stderr(true)
+                .attach_stdout(true)
+                .command([
+                    "bash",
+                    "-c",
+                    "mkdir /tmp/test123 && echo 1234 >> /tmp/test123/testfile",
+                ])
+                .build(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
     while exec_stream.next().await.is_some() {}
 
-    let mut exec_stream = container.exec(
-        &ExecCreateOpts::builder()
-            .attach_stderr(true)
-            .attach_stdout(true)
-            .command(["cat", "test123/testfile"])
-            .working_dir("/tmp")
-            .build(),
-    );
+    let mut exec_stream = container
+        .exec(
+            &ExecCreateOpts::builder()
+                .attach_stderr(true)
+                .attach_stdout(true)
+                .command(["cat", "test123/testfile"])
+                .working_dir("/tmp")
+                .build(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
     let chunk = exec_stream.next().await;
     assert!(chunk.is_some());
     match chunk.unwrap() {
@@ -308,17 +316,21 @@ async fn container_copy_from() {
 
     let _ = container.start().await;
 
-    let mut exec_stream = container.exec(
-        &ExecCreateOpts::builder()
-            .attach_stderr(true)
-            .attach_stdout(true)
-            .command([
-                "bash",
-                "-c",
-                "mkdir /tmp/test123 && echo 1234 >> /tmp/test123/test-copy-from",
-            ])
-            .build(),
-    );
+    let mut exec_stream = container
+        .exec(
+            &ExecCreateOpts::builder()
+                .attach_stderr(true)
+                .attach_stdout(true)
+                .command([
+                    "bash",
+                    "-c",
+                    "mkdir /tmp/test123 && echo 1234 >> /tmp/test123/test-copy-from",
+                ])
+                .build(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
     while exec_stream.next().await.is_some() {}
 
     let tar_stream = container.copy_from("/tmp/test123");
@@ -347,13 +359,17 @@ async fn container_copy_file_into() {
     let copy_result = container.copy_file_into("/tmp/test-file", data).await;
     assert!(copy_result.is_ok());
 
-    let mut exec_stream = container.exec(
-        &ExecCreateOpts::builder()
-            .attach_stderr(true)
-            .attach_stdout(true)
-            .command(["cat", "/tmp/test-file"])
-            .build(),
-    );
+    let mut exec_stream = container
+        .exec(
+            &ExecCreateOpts::builder()
+                .attach_stderr(true)
+                .attach_stdout(true)
+                .command(["cat", "/tmp/test-file"])
+                .build(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
     let chunk = exec_stream.next().await;
     assert!(chunk.is_some());
     match chunk.unwrap() {
@@ -378,17 +394,21 @@ async fn container_changes() {
 
     let _ = container.start().await;
 
-    let mut exec_stream = container.exec(
-        &ExecCreateOpts::builder()
-            .attach_stderr(true)
-            .attach_stdout(true)
-            .command([
-                "bash",
-                "-c",
-                "rm /etc/xattr.conf && echo 12345 >> /tmp/test-changes",
-            ])
-            .build(),
-    );
+    let mut exec_stream = container
+        .exec(
+            &ExecCreateOpts::builder()
+                .attach_stderr(true)
+                .attach_stdout(true)
+                .command([
+                    "bash",
+                    "-c",
+                    "rm /etc/xattr.conf && echo 12345 >> /tmp/test-changes",
+                ])
+                .build(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
     while exec_stream.next().await.is_some() {}
 
     use docker_api::models::ContainerChangeResponseItem;


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Changed exec to handle stdin by acting similar to the attach method.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #53 

## How did you verify your change:

Tested locally by running an exec `apt upgrade` in a ubuntu container and the writing to the multiplexer `y` to do the upgrade and it worked. 