### PR TITLE
added runtime option to ContainerCreateOptsBuilder

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -620,6 +620,11 @@ impl ContainerCreateOptsBuilder {
     /// Represents the container's networking configuration for each of its interfaces.
         network_config: NetworkingConfig => "NetworkingConfig"
     );
+
+    impl_str_field!(
+        /// Runtime to use for this container like "nvidia"
+        runtime => "HostConfig.Runtime"
+    );
 }
 
 impl_opts_builder!(url => ContainerRemove);


### PR DESCRIPTION
Added "runtime" option for creating Docker container that allows using NVidia GPU inside the container like [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) equivalent to the command `docker run --runtime=nvidia nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi`