### PR TITLE
added device_requests option to container create

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -1,4 +1,4 @@
-use crate::models::{Labels, NetworkingConfig};
+use crate::models::{DeviceRequest, Labels, NetworkingConfig};
 use crate::opts::ImageName;
 use containers_api::opts::{Filter, FilterItem};
 use containers_api::{
@@ -624,6 +624,11 @@ impl ContainerCreateOptsBuilder {
     impl_str_field!(
         /// Runtime to use for this container like "nvidia"
         runtime => "HostConfig.Runtime"
+    );
+
+    impl_field!(
+        /// Requested list of available devices with capabilities
+        device_requests: Vec<DeviceRequest> => "HostConfig.DeviceRequests"
     );
 }
 


### PR DESCRIPTION
This change was motivated by the need to run Docker on Windows with GPU (CUDA) support. On Linux it seemed enough to add the `HostConfig.Runtime` option. On Windows needed to provide the device request specification. Like in [this](https://stackoverflow.com/a/71429712/1008902) example.

Unfortunately this part of Docker API is poorly documented, so this change is largely based on the Python SDK code, specifically [DeviceRequest](https://github.com/docker/docker-py/blob/9cadad009e6aa78e15d752e2011705d7d91b8d2e/docker/types/containers.py#L155) structure.

Nonetheless, the container with GPU device request specified with this API works both on Linux and Windows.