### PR TITLE
Added log driver config to container create opts

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -557,6 +557,8 @@ impl ContainerCreateOptsBuilder {
 
     impl_str_field!(log_driver => "HostConfig.LogConfig.Type");
 
+    impl_map_field!(json log_driver_config => "HostConfig.LogConfig.Config");
+
     pub fn restart_policy(mut self, name: &str, maximum_retry_count: u64) -> Self {
         self.params
             .insert("HostConfig.RestartPolicy.Name", json!(name));
@@ -845,6 +847,13 @@ mod tests {
                 .image("test_image")
                 .log_driver("fluentd"),
             r#"{"HostConfig":{"LogConfig":{"Type":"fluentd"}},"Image":"test_image"}"#
+        );
+
+        test_case!(
+            ContainerCreateOptsBuilder::default()
+                .image("test_image")
+                .log_driver_config(vec![("tag", "container-tag")]),
+            r#"{"HostConfig":{"LogConfig":{"Config":{"tag":"container-tag"}}},"Image":"test_image"}"#
         );
 
         test_case!(


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Added log_driver_config to `ContainerCreateOptsBuilder`.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:

Added a test case to `create_container_opts`, also did a manual test on local docker daemon with
```rust
            .log_driver("journald")
            .log_driver_config(vec![("tag", "ctag")])
```
and checked with  `journalctl CONTAINER_TAG=ctag` to verify it works.

## What (if anything) would need to be called out in the CHANGELOG for the next release: