### PR TITLE
Don't tie Multiplexer lifetime to Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Exec::start` and `Container::exec` signature changed. It is now async and returns a result with `tty::Multiplexer` (same as attach) 
   so that it can handle writing to STDIN.
 - Add `ContainerCreateOptsBuilder::log_driver_config`
+- `tty::Multiplexer` now doesn't rely on Docker client lifetime - this means a change in function signature for `Container::attach`, `Container::exec` and `Exec::start`
 
 # 0.13.0
 - Fix Container::attach output when TTY is enabled on container

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ edition = "2021"
 readme = "README.md"
 
 [dependencies]
-containers-api = "0.8"
-#containers-api = { git = "https://github.com/vv9k/containers-api" }
+#containers-api = "0.8"
+#containers-api = { path = "../containers-api" }
+containers-api = { git = "https://github.com/vv9k/containers-api" }
 
 docker-api-stubs = "0.5"
 #docker-api-stubs = { path = "./docker-api-stubs/lib" }

--- a/src/api/container.rs
+++ b/src/api/container.rs
@@ -47,11 +47,11 @@ impl Container {
     /// The [`TtyMultiplexer`](TtyMultiplexer) implements Stream for returning Stdout and Stderr chunks. It also implements [`AsyncWrite`](futures_util::io::AsyncWrite) for writing to Stdin.
     ///
     /// The multiplexer can be split into its read and write halves with the [`split`](TtyMultiplexer::split) method
-    pub async fn attach(&self) -> Result<tty::Multiplexer<'_>> {
+    pub async fn attach(&self) -> Result<tty::Multiplexer> {
         let inspect = self.inspect().await?;
         let is_tty = inspect.config.and_then(|c| c.tty).unwrap_or_default();
         stream::attach(
-            &self.docker,
+            self.docker.clone(),
             format!(
                 "/containers/{}/attach?stream=1&stdout=1&stderr=1&stdin=1",
                 self.id
@@ -215,12 +215,12 @@ impl Container {
     api_doc! { Exec
     |
     /// Execute a command in this container.
-    pub async fn exec<'docker>(
-        &'docker self,
+    pub async fn exec(
+        &self,
         create_opts: &ExecCreateOpts,
         start_opts: &ExecStartOpts,
-    ) ->  Result<tty::Multiplexer<'docker>> {
-        Exec::create_and_start(&self.docker, &self.id, create_opts, start_opts).await
+    ) ->  Result<tty::Multiplexer> {
+        Exec::create_and_start(self.docker.clone(), &self.id, create_opts, start_opts).await
     }}
 
     api_doc! { Container => Archive

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -80,13 +80,13 @@ impl Exec {
             .map(|id| Exec::new(docker, id))
     }}
 
-    async fn start_impl<'docker>(
-        docker: &'docker Docker,
+    async fn start_impl(
+        docker: Docker,
         id: &str,
         opts: &ExecStartOpts,
-    ) -> Result<tty::Multiplexer<'docker>> {
+    ) -> Result<tty::Multiplexer> {
         let endpoint = format!("/exec/{}/start", id);
-        let inspect_data = Self::inspect_impl(docker, id).await?;
+        let inspect_data = Self::inspect_impl(&docker, id).await?;
         let is_tty = inspect_data
             .process_config
             .and_then(|c| c.tty)
@@ -104,16 +104,16 @@ impl Exec {
     api_doc! { Exec => Start
     |
     /// Starts this exec instance returning a multiplexed tty stream.
-    pub async fn start(&self, opts: &ExecStartOpts) -> Result<tty::Multiplexer<'_>> {
-        Self::start_impl(&self.docker, self.id.as_ref(), opts).await
+    pub async fn start(&self, opts: &ExecStartOpts) -> Result<tty::Multiplexer> {
+        Self::start_impl(self.docker.clone(), self.id.as_ref(), opts).await
     }}
 
-    pub(crate) async fn create_and_start<'docker>(
-        docker: &'docker Docker,
+    pub(crate) async fn create_and_start(
+        docker: Docker,
         container_id: impl AsRef<str>,
         create_opts: &ExecCreateOpts,
         start_opts: &ExecStartOpts,
-    ) -> Result<tty::Multiplexer<'docker>> {
+    ) -> Result<tty::Multiplexer> {
         let container_id = container_id.as_ref();
         let id = Self::create_impl(docker.clone(), container_id, create_opts).await?;
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -371,17 +371,16 @@ impl Docker {
         self.client.get_stream(self.make_endpoint(endpoint))
     }
 
-    pub(crate) async fn post_upgrade_stream<'a, B>(
-        &'a self,
-        endpoint: impl AsRef<str> + 'a,
+    pub(crate) async fn post_upgrade_stream<B>(
+        self,
+        endpoint: impl AsRef<str>,
         body: Payload<B>,
-    ) -> Result<impl AsyncRead + AsyncWrite + 'a>
+    ) -> Result<impl AsyncRead + AsyncWrite>
     where
-        B: Into<Body> + 'a,
+        B: Into<Body>,
     {
-        self.client
-            .post_upgrade_stream(self.make_endpoint(endpoint), body)
-            .await
+        let ep = self.make_endpoint(endpoint);
+        self.client.post_upgrade_stream(ep, body).await
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -7,19 +7,19 @@ use crate::{Docker, Result};
 
 /// Attaches a multiplexed TCP stream to the container that can be used to read Stdout, Stderr and write Stdin.
 async fn attach_raw(
-    docker: &Docker,
+    docker: Docker,
     endpoint: String,
     payload: Payload<Body>,
-) -> Result<impl AsyncRead + AsyncWrite + Send + '_> {
+) -> Result<impl AsyncRead + AsyncWrite + Send> {
     docker.post_upgrade_stream(endpoint, payload).await
 }
 
 pub async fn attach(
-    docker: &Docker,
+    docker: Docker,
     endpoint: String,
     payload: Payload<Body>,
     is_tty: bool,
-) -> Result<tty::Multiplexer<'_>> {
+) -> Result<tty::Multiplexer> {
     attach_raw(docker, endpoint, payload).await.map(|s| {
         if is_tty {
             tty::Multiplexer::new(s, tty::decode_raw)


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

This PR changes the signature of Multiplexer so that it is not tied to the Docker struct, it now takes a clone of the client so that it is easier to return the Multiplexer from a function.

Closes: #59 

## How did you verify your change:

## What (if anything) would need to be called out in the CHANGELOG for the next release: