### PR TITLE
Added to 'reference' image filter + tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
 2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
-clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
+clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
 -->
 
 ## What did you implement:

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ lint:
 .PHONY: clean
 clean:
 	rm -rf target docker-api-stubs/target
+
+.PHONY: fmt
+fmt:
+	cargo +nightly fmt --all

--- a/tests/image_tests.rs
+++ b/tests/image_tests.rs
@@ -208,6 +208,28 @@ async fn image_list() {
     assert!(!list_data.iter().any(|report| report.id == full_id_a));
     assert!(list_data.iter().any(|report| report.id == full_id_b));
 
+    let filter = opts::ImageFilter::Reference(name_a.to_string(), None);
+    let list_opts = opts::ImageListOpts::builder()
+        .filter([filter])
+        .all(true)
+        .build();
+    let list_result = images.list(&list_opts).await;
+    assert!(list_result.is_ok());
+    let list_data = list_result.unwrap();
+    assert_eq!(list_data.len(), 1);
+    assert_eq!(full_id_a, list_data[0].id);
+
+    let filter = opts::ImageFilter::Reference(name_a.to_string(), Some("latest".to_string()));
+    let list_opts = opts::ImageListOpts::builder()
+        .filter([filter])
+        .all(true)
+        .build();
+    let list_result = images.list(&list_opts).await;
+    assert!(list_result.is_ok());
+    let list_data = list_result.unwrap();
+    assert_eq!(list_data.len(), 1);
+    assert_eq!(full_id_a, list_data[0].id);
+
     let _ = image_a.delete().await;
     let _ = image_b.delete().await;
 }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Added `Reference` variant to `ImageFilter` to enable listing by name and tag. Also added a `fmt` target to the makefile just to make it a bit more convenient to run (added this to the pull request template).

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:

Added `test_image_filter_reference`  to `opts/images.rs` and two cases to `image_list` integration test. Also tested manually.

## What (if anything) would need to be called out in the CHANGELOG for the next release: