### PR TITLE
Added port binding to specific host ip

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -880,13 +880,6 @@ mod tests {
         test_case!(
             ContainerCreateOptsBuilder::default()
                 .image("test_image")
-                .expose(PublishPort::tcp(80), 8080),
-            r#"{"ExposedPorts":{"80/tcp":{}},"HostConfig":{"PortBindings":{"80/tcp":[{"HostPort":"8080"}]}},"Image":"test_image"}"#
-        );
-
-        test_case!(
-            ContainerCreateOptsBuilder::default()
-                .image("test_image")
                 .expose(
                     PublishPort::tcp(80),
                     "[::1]:8080".parse::<SocketAddr>().unwrap()


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Added the option to bind a host port on a host IP. Added `HostPort`, made `expose` generic, and implemented `From<u32>` for `HostPort` to not break existing code. Also added a `From<SocketAddr>` implementation for convenience.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:

Added a test case to `create_container_opts`, also verified manually.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Mention the `expose` signature change