### PR TITLE
Add init field to create container options

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -631,6 +631,12 @@ impl ContainerCreateOptsBuilder {
 
     impl_field!(privileged: bool => "HostConfig.Privileged");
 
+    impl_field!(
+        /// Run an init inside the container that forwards signals and reaps processes. This field is
+        /// omitted if empty, and the default (as configured on the daemon) is used.
+        init: bool => "HostConfig.Init"
+    );
+
     impl_str_field!(user => "User");
 
     pub fn build(&self) -> ContainerCreateOpts {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Added support for the [init field](https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerCreate) to [the create container options builder](https://docs.rs/docker-api/latest/docker_api/opts/struct.ContainerCreateOptsBuilder.html).

## How did you verify your change:
I ran `cargo test` and I have been using updated version of the library in one of my projects.