### PR TITLE
automatically detect client host endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ hyper = { version="0.14", features=["client", "http1", "tcp", "stream"] }
 hyper-openssl = { version="0.9", optional=true }
 openssl = { version="0.10", optional=true }
 
+anyhow = { version="1.0", optional=true }
+dirs = { version="5.0", optional=true }
+hex = { version="0.4", optional=true }
+sha2 = { version="0.10", optional=true }
+
 [dev-dependencies]
 env_logger = "0.9"
 # Required for examples to run
@@ -65,7 +70,7 @@ tls = ["containers-api/tls"]
 vendored-ssl = ["tls", "containers-api/vendored-ssl"]
 par-compress = ["containers-api/par-compress"]
 swarm = []
-
+detect-host = ["dep:anyhow", "dep:dirs", "dep:hex", "dep:sha2"]
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ hyper = { version="0.14", features=["client", "http1", "tcp", "stream"] }
 hyper-openssl = { version="0.9", optional=true }
 openssl = { version="0.10", optional=true }
 
-anyhow = { version="1.0", optional=true }
 dirs = { version="5.0", optional=true }
 hex = { version="0.4", optional=true }
 sha2 = { version="0.10", optional=true }
@@ -70,7 +69,7 @@ tls = ["containers-api/tls"]
 vendored-ssl = ["tls", "containers-api/vendored-ssl"]
 par-compress = ["containers-api/par-compress"]
 swarm = []
-detect-host = ["dep:anyhow", "dep:dirs", "dep:hex", "dep:sha2"]
+detect-host = ["dep:dirs", "dep:hex", "dep:sha2"]
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -2,7 +2,6 @@
 //!
 //! Reference: <https://github.com/docker/cli/blob/v24.0.5/opts/hosts.go#L11-L33>
 
-use anyhow::Context;
 use dirs::home_dir;
 use env_vars::{DOCKER_CONFIG, DOCKER_CONTEXT, DOCKER_HOST};
 use sha2::{Digest, Sha256};

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -62,8 +62,8 @@ pub enum EndpointError {
 /// # Fails when
 /// * Cannot find docker config directory
 /// * `DOCKER_CONTEXT` is defined and is invalid
-/// * `config.js` file exists and fails to read or parse it
-/// * `config.js` have the `currentContext` property defined, but fails to find the context endpoint
+/// * `config.json` file exists and fails to read or parse it
+/// * `config.json` have the `currentContext` property defined, but fails to find the context endpoint
 pub fn find_docker_host() -> Result<String, EndpointError> {
     // If defined, Load the endpoint from the `DOCKER_CONTEXT` environment variable
     if let Some(context) = env_vars::non_empty_var(DOCKER_CONTEXT) {
@@ -111,11 +111,11 @@ pub fn docker_config_dir() -> Result<PathBuf, EndpointError> {
 /// Attempts to load the endpoint from the `.docker/config.json` file
 ///
 /// # Returns
-/// * Ok(Some(host)) - if the config.js exists and contains currentContext field
-/// * Ok(None) - if the config.js exists and not contain currentContext field
+/// * Ok(Some(host)) - if the config.json exists and contains currentContext field
+/// * Ok(None) - if the config.json exists and not contain currentContext field
 ///
 /// # Fails when
-/// * config.js doesn't exists
+/// * config.json doesn't exists
 /// * cannot read or parse the config.js file
 /// * the currentContext is defined, but fails to load the context endpoint
 pub fn host_from_config_file(config_file: PathBuf) -> Result<Option<String>, EndpointError> {

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -183,7 +183,7 @@ pub fn host_from_metadata_file(meta_filepath: PathBuf) -> Result<String, Endpoin
 /// Parsers a file to a json value
 fn file_to_json(filepath: &PathBuf) -> Result<serde_json::Value, EndpointError> {
     fs::read_to_string(filepath)
-        .map_err(|error| EndpointError::IOError(error))?
+        .map_err(EndpointError::IOError)?
         .parse::<serde_json::Value>()
         .map_err(|error| EndpointError::InvalidJson {
             filepath: filepath.clone(),

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -1,0 +1,201 @@
+//! Auto detect the docker endpoint the same way docker-cli does
+//!
+//! Reference: <https://github.com/docker/cli/blob/v24.0.5/opts/hosts.go#L11-L33>
+
+use anyhow::Context;
+use dirs::home_dir;
+use env_vars::{DOCKER_CONFIG, DOCKER_CONTEXT, DOCKER_HOST};
+use sha2::{Digest, Sha256};
+use std::{fs, path::PathBuf, str::FromStr};
+
+#[cfg(unix)]
+pub const DEFAULT_DOCKER_ENDPOINT: &str = "unix:///var/run/docker.sock";
+
+/// For windows the default endpoint is "npipe:////./pipe/docker_engine"
+/// But currently this is not supported by docker-api, using to default tcp endpoint instead
+/// https://github.com/vv9k/docker-api-rs/issues/57
+#[cfg(not(unix))]
+pub const DEFAULT_DOCKER_ENDPOINT: &str = "tcp://127.0.0.1:2375";
+
+/// List of environment variables supported by the `docker` command
+pub(crate) mod env_vars {
+    use std::ffi::OsStr;
+
+    /// The location of your client configuration files.
+    pub const DOCKER_CONFIG: &str = "DOCKER_CONFIG";
+
+    /// Name of the `docker context` to use (overrides `DOCKER_HOST` env var and default context set with `docker context use`)
+    pub const DOCKER_CONTEXT: &str = "DOCKER_CONTEXT";
+
+    /// Daemon socket to connect to.
+    pub const DOCKER_HOST: &str = "DOCKER_HOST";
+
+    /// Load an environment variable and verify if it's not empty
+    pub fn non_empty_var<K: AsRef<OsStr>>(key: K) -> Option<String> {
+        let value = std::env::var(key).ok()?;
+        if value.trim().is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+}
+
+enum EndpointError {
+    InvalidEndpoint,
+    CannotFindUserHomeDir,
+    InvalidJson {
+        filepath: PathBuf,
+        error: serde_json::Error,
+    },
+    IOError(std::io::Error),
+}
+
+/// Find the docker host the same way as docker-cli does
+///
+/// # Steps
+/// 1. Try to load the endpoint from the `DOCKER_CONTEXT` environment variable
+/// 2. Try to load the endpoint from the `DOCKER_HOST` environment variable
+/// 3. Try to load the endpoint from the `config.json` file
+/// 4. Return the default endpoint
+///
+/// # Fails when
+/// * Cannot find docker config directory
+/// * `DOCKER_CONTEXT` is defined and is invalid
+/// * `config.js` file exists and fails to read or parse it
+/// * `config.js` have the `currentContext` property defined, but fails to find the context endpoint
+pub fn find_docker_host() -> Result<String, EndpointError> {
+    // If defined, Load the endpoint from the `DOCKER_CONTEXT` environment variable
+    if let Some(context) = env_vars::non_empty_var(DOCKER_CONTEXT) {
+        let config_directory = docker_config_dir()?;
+        return host_from_context(&context, config_directory);
+    }
+
+    // If defined, return the host from the `DOCKER_HOST` environment variable
+    if let Some(host) = env_vars::non_empty_var(DOCKER_HOST) {
+        return Ok(host);
+    }
+
+    // If the config.json file exists, try to load the endpoint from it
+    let config_file = docker_config_dir().map(|config_dir| config_dir.join("config.json"))?;
+    if config_file.exists() {
+        let maybe_host = host_from_config_file(config_file)?;
+        return maybe_host.ok_or_else(|| EndpointError::InvalidEndpoint);
+    }
+
+    // otherwise return the default endpoint
+    Ok(DEFAULT_DOCKER_ENDPOINT.to_string())
+}
+
+/// By default, the Docker-cli stores its configuration files in a directory called
+/// `.docker` within your `$HOME` directory. the default location can be overridden by
+/// the `DOCKER_CONFIG` environment variable.
+///
+/// Reference:
+/// https://github.com/docker/cli/blob/v24.0.5/man/docker-config-json.5.md
+///
+/// Fails if the user home directory cannot be found
+pub fn docker_config_dir() -> Result<PathBuf, EndpointError> {
+    // Try to load the config directory from the `DOCKER_CONFIG` environment variable
+    if let Some(config_directory) = env_vars::non_empty_var(DOCKER_CONFIG).map(PathBuf::from) {
+        return Ok(config_directory);
+    }
+
+    // Use the default config directory at $HOME/.docker/
+    let Some(config_directory) = home_dir().map(|path| path.join(".docker/")) else {
+        return Err(EndpointError::CannotFindUserHomeDir)
+    };
+    Ok(config_directory)
+}
+
+/// Attempts to load the endpoint from the `.docker/config.json` file
+///
+/// # Returns
+/// * Ok(Some(host)) - if the config.js exists and contains currentContext field
+/// * Ok(None) - if the config.js exists and not contain currentContext field
+///
+/// # Fails when
+/// * config.js doesn't exists
+/// * cannot read or parse the config.js file
+/// * the currentContext is defined, but fails to load the context endpoint
+pub fn host_from_config_file(config_file: PathBuf) -> Result<Option<String>, EndpointError> {
+    // Read the config.json file and extract the current context
+    let config_file_json = file_to_json(&config_file)?;
+
+    // Check if the config file has the property currentContext
+    let current_context = config_file_json
+        .get("currentContext")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
+    if let Some(context) = current_context {
+        let config_directory = config_file
+            .parent()
+            .map(|config_dir| config_dir.to_path_buf())
+            .unwrap_or_default();
+        let endpoint = host_from_context(&context, config_directory)?;
+        Ok(Some(endpoint))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Load the Host of a given context, the context's host is located at:
+/// UNIX:
+///  - $HOME/.docker/contexts/meta/<sha256 context>/meta.json
+/// Windows:
+/// - %USERPROFILE%\.docker\contexts\meta\<sha256 context>\meta.json
+///
+/// Is possible to list contexts by running `docker context ls`
+pub fn host_from_context(
+    context: &str,
+    mut config_directory: PathBuf,
+) -> Result<String, EndpointError> {
+    let metadata_filepath = {
+        // $HOME/.docker/contexts/meta/<sha256 context>/meta.json
+        let digest = sha256_digest(context);
+        config_directory.extend(["contexts", "meta", digest.as_str(), "meta.json"]);
+        config_directory
+    };
+
+    host_from_metadata_file(metadata_filepath)
+}
+
+/// Parses the `meta.json` file and extract the docker endpoint
+/// The endpoint is located at: `meta.Endpoints.Endpoints.docker.Host`
+pub fn host_from_metadata_file(meta_filepath: PathBuf) -> Result<String, EndpointError> {
+    let meta_json = file_to_json(&meta_filepath)?;
+
+    let host = meta_json
+        .get("Endpoints")
+        .and_then(|value| value.get("Endpoints"))
+        .and_then(|value| value.get("docker"))
+        .and_then(|value| value.get("Host"))
+        .and_then(|value| value.as_str())
+        .ok_or_else(|error| EndpointError::InvalidJson {
+            filepath: meta_filepath,
+            error,
+        })?
+        .to_string();
+
+    Ok(host)
+}
+
+/// Parsers a file to a json value
+fn file_to_json(filepath: &PathBuf) -> Result<serde_json::Value, EndpointError> {
+    fs::read_to_string(filepath)
+        .map_err(|error| EndpointError::IOError(error))?
+        .parse::<serde_json::Value>()
+        .map_err(|error| EndpointError::InvalidJson {
+            filepath: filepath.clone(),
+            error,
+        })
+}
+
+/// Returns the sha256 hex-digest of a given string
+fn sha256_digest(name: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(name.as_bytes());
+    let result = hasher.finalize();
+    hex::encode(result)
+}

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -103,7 +103,7 @@ pub fn docker_config_dir() -> Result<PathBuf, EndpointError> {
 
     // Use the default config directory at $HOME/.docker/
     let Some(config_directory) = home_dir().map(|path| path.join(".docker/")) else {
-        return Err(EndpointError::CannotFindUserHomeDir)
+        return Err(EndpointError::CannotFindUserHomeDir);
     };
     Ok(config_directory)
 }

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -4,8 +4,9 @@
 
 use dirs::home_dir;
 use env_vars::{DOCKER_CONFIG, DOCKER_CONTEXT, DOCKER_HOST};
+use serde::de::Error as SerdeError;
 use sha2::{Digest, Sha256};
-use std::{fs, path::PathBuf, str::FromStr};
+use std::{fs, path::PathBuf};
 
 #[cfg(unix)]
 pub const DEFAULT_DOCKER_ENDPOINT: &str = "unix:///var/run/docker.sock";
@@ -167,13 +168,12 @@ pub fn host_from_metadata_file(meta_filepath: PathBuf) -> Result<String, Endpoin
 
     let host = meta_json
         .get("Endpoints")
-        .and_then(|value| value.get("Endpoints"))
         .and_then(|value| value.get("docker"))
         .and_then(|value| value.get("Host"))
         .and_then(|value| value.as_str())
-        .ok_or_else(|error| EndpointError::InvalidJson {
+        .ok_or_else(|| EndpointError::InvalidJson {
             filepath: meta_filepath,
-            error,
+            error: SerdeError::missing_field("Endpoints.docker.Host"),
         })?
         .to_string();
 

--- a/src/detect_host.rs
+++ b/src/detect_host.rs
@@ -41,8 +41,8 @@ pub(crate) mod env_vars {
     }
 }
 
-enum EndpointError {
-    InvalidEndpoint,
+#[derive(Debug)]
+pub enum EndpointError {
     CannotFindUserHomeDir,
     InvalidJson {
         filepath: PathBuf,
@@ -80,7 +80,7 @@ pub fn find_docker_host() -> Result<String, EndpointError> {
     let config_file = docker_config_dir().map(|config_dir| config_dir.join("config.json"))?;
     if config_file.exists() {
         let maybe_host = host_from_config_file(config_file)?;
-        return maybe_host.ok_or_else(|| EndpointError::InvalidEndpoint);
+        return Ok(maybe_host.unwrap_or_else(|| DEFAULT_DOCKER_ENDPOINT.to_string()));
     }
 
     // otherwise return the default endpoint

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -16,6 +16,7 @@ use crate::conn::get_https_connector;
 #[cfg(unix)]
 use crate::conn::get_unix_connector;
 
+use crate::detect_host::DEFAULT_DOCKER_ENDPOINT;
 use futures_util::{
     io::{AsyncRead, AsyncWrite},
     stream::Stream,
@@ -31,6 +32,21 @@ use std::pin::Pin;
 pub struct Docker {
     version: Option<ApiVersion>,
     client: RequestClient<Error>,
+}
+
+#[cfg(feature = "detect-host")]
+impl Default for Docker {
+    fn default() -> Self {
+        use crate::detect_host::{find_docker_host, DEFAULT_DOCKER_ENDPOINT};
+        // Try to connect to the configured host, otherwise connect to default endpoint
+        find_docker_host()
+            .ok()
+            .and_then(|endpoint| Self::new(endpoint).ok())
+            .unwrap_or_else(|| {
+                Self::new(DEFAULT_DOCKER_ENDPOINT)
+                    .expect("the default endpoint is always valid: qed")
+            })
+    }
 }
 
 impl Docker {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -16,7 +16,9 @@ use crate::conn::get_https_connector;
 #[cfg(unix)]
 use crate::conn::get_unix_connector;
 
-use crate::detect_host::DEFAULT_DOCKER_ENDPOINT;
+#[cfg(feature = "detect-host")]
+use crate::detect_host::{find_docker_host, DEFAULT_DOCKER_ENDPOINT};
+
 use futures_util::{
     io::{AsyncRead, AsyncWrite},
     stream::Stream,
@@ -37,7 +39,6 @@ pub struct Docker {
 #[cfg(feature = "detect-host")]
 impl Default for Docker {
     fn default() -> Self {
-        use crate::detect_host::{find_docker_host, DEFAULT_DOCKER_ENDPOINT};
         // Try to connect to the configured host, otherwise connect to default endpoint
         find_docker_host()
             .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,9 @@ pub mod conn {
     pub(crate) use containers_api::conn::*;
     pub use containers_api::conn::{Error, Transport, TtyChunk};
 }
-pub mod docker;
 #[cfg(feature = "detect-host")]
 pub mod detect_host;
+pub mod docker;
 pub mod errors;
 pub mod opts;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod conn {
     pub use containers_api::conn::{Error, Transport, TtyChunk};
 }
 pub mod docker;
+#[cfg(feature = "detect-host")]
+pub mod detect_host;
 pub mod errors;
 pub mod opts;
 


### PR DESCRIPTION
## What did you implement:
Automatically detect the client host endpoint, the same way as [docker-cli](https://github.com/docker/cli/blob/v24.0.5/opts/hosts.go#L11-L33) does.

I've implemented this feature in a project I'm working, so I decided to open a PR here in case you think this could be useful.

### Steps
1. Try to load the endpoint from the `DOCKER_CONTEXT` environment variable
2. Try to load the endpoint from the `DOCKER_HOST` environment variable
3. Try to load the endpoint from the `config.json` file
4. otherwise use the default endpoint
