### PR TITLE
Add Binds to HostConfig

### DIFF
--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -89,7 +89,7 @@ impl Image {
         let headers = opts
             .auth_header()
             .map(|auth| Headers::single(AUTH_HEADER, auth))
-            .unwrap_or_else(Headers::default);
+            .unwrap_or_default();
 
         self.docker
             .post_string(&ep, Payload::empty(), Some(headers))

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -601,6 +601,8 @@ impl ContainerCreateOptsBuilder {
 
     impl_map_field!(json log_driver_config => "HostConfig.LogConfig.Config");
 
+    impl_vec_field!(binds => "HostConfig.Binds");
+
     pub fn restart_policy(mut self, name: &str, maximum_retry_count: u64) -> Self {
         self.params
             .insert("HostConfig.RestartPolicy.Name", json!(name));
@@ -912,6 +914,13 @@ mod tests {
                 .image("test_image")
                 .log_driver_config(vec![("tag", "container-tag")]),
             r#"{"HostConfig":{"LogConfig":{"Config":{"tag":"container-tag"}}},"Image":"test_image"}"#
+        );
+
+        test_case!(
+            ContainerCreateOptsBuilder::default()
+                .image("test_image")
+                .binds(vec![("/etc/hosts:/etc/hosts:ro")]),
+            r#"{"HostConfig":{"Binds":["/etc/hosts:/etc/hosts:ro"]},"Image":"test_image"}"#
         );
 
         test_case!(

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -677,12 +677,11 @@ async fn container_attach() {
     let _ = container.start().await;
 
     let mut multiplexer = container.attach().await.unwrap();
-    while let Some(chunk) = multiplexer.next().await {
+    if let Some(chunk) = multiplexer.next().await {
         match chunk {
             Ok(TtyChunk::StdOut(chunk)) => {
                 let logs = String::from_utf8_lossy(&chunk);
                 assert_eq!(logs, "123456\r\n");
-                break;
             }
             chunk => {
                 eprintln!("invalid chunk {chunk:?}");
@@ -713,12 +712,11 @@ async fn container_attach() {
     let _ = container.start().await;
 
     let mut multiplexer = container.attach().await.unwrap();
-    while let Some(chunk) = multiplexer.next().await {
+    if let Some(chunk) = multiplexer.next().await {
         match chunk {
             Ok(TtyChunk::StdOut(chunk)) => {
                 let logs = String::from_utf8_lossy(&chunk);
                 assert_eq!(logs, "123456\n");
-                break;
             }
             chunk => {
                 eprintln!("invalid chunk {chunk:?}");


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Added `HostConfig.Binds` to mount host files/directories inside the container.

## How did you verify your change:

Added test case to `create_container_opts` and tested locally.

## What (if anything) would need to be called out in the CHANGELOG for the next release: