### PR TITLE
Podman Support in tests, Read-only rootfs and resizeable TTY

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,5 +47,5 @@ jobs:
       - name: Test
         run: |
           docker pull ubuntu:latest
-          cargo test --all-features --all-targets
+          cargo test --all-features --all-targets -j1
           cargo test --doc

--- a/examples/container.rs
+++ b/examples/container.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match opts.subcmd {
         Cmd::Attach { id } => {
             let container = docker.containers().get(&id);
-            let tty_multiplexer = container.attach().await?;
+            let tty_multiplexer = container.attach(false).await?;
 
             let (mut reader, _writer) = tty_multiplexer.split();
 

--- a/src/api/container.rs
+++ b/src/api/container.rs
@@ -171,6 +171,20 @@ impl Container {
             .map(|_| ())
     }}
 
+    api_doc! { Container => Resize
+    |
+    /// Resize the TTY for a container
+    pub async fn resize(&self, width: u16, height: u16) -> Result<()> {
+        self.docker
+            .post_string(
+                &format!("/containers/{}/resize?w={width}&h={height}", self.id),
+                Payload::empty(),
+                Headers::none()
+            )
+            .await
+            .map(|_| ())
+    }}
+
     api_doc! { Container => Pause
     |
     /// Pause the container instance.

--- a/src/api/container.rs
+++ b/src/api/container.rs
@@ -47,13 +47,18 @@ impl Container {
     /// The [`TtyMultiplexer`](TtyMultiplexer) implements Stream for returning Stdout and Stderr chunks. It also implements [`AsyncWrite`](futures_util::io::AsyncWrite) for writing to Stdin.
     ///
     /// The multiplexer can be split into its read and write halves with the [`split`](TtyMultiplexer::split) method
-    pub async fn attach(&self) -> Result<tty::Multiplexer> {
+    pub async fn attach(&self, logs: bool) -> Result<tty::Multiplexer> {
         let inspect = self.inspect().await?;
+        let logs = if logs {
+                1
+            } else {
+                0
+            };
         let is_tty = inspect.config.and_then(|c| c.tty).unwrap_or_default();
         stream::attach(
             self.docker.clone(),
             format!(
-                "/containers/{}/attach?stream=1&stdout=1&stderr=1&stdin=1",
+                "/containers/{}/attach?stream=1&stdout=1&stderr=1&stdin=1&logs={logs}",
                 self.id
             ),
             Payload::empty(),

--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -89,7 +89,7 @@ impl Image {
         let headers = opts
             .auth_header()
             .map(|auth| Headers::single(AUTH_HEADER, auth))
-            .unwrap_or_else(Headers::default);
+            .unwrap_or_default();
 
         self.docker
             .post_string(&ep, Payload::empty(), Some(headers))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,7 +28,7 @@ pub mod swarm;
 #[cfg_attr(docsrs, doc(cfg(feature = "swarm")))]
 pub mod task;
 
-pub use {container::*, exec::*, image::*, network::*, system::*, volume::*};
+pub use {container::*, exec::*, image::*, network::*, volume::*};
 
 #[cfg(feature = "swarm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "swarm")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ mod stream;
 pub mod conn {
     //! Connection related items
     pub(crate) use containers_api::conn::*;
-    pub use containers_api::conn::{Error, Transport, TtyChunk};
+    pub use containers_api::conn::{
+        tty::Multiplexer as TtyMultiplexer, Error, Transport, TtyChunk,
+    };
 }
 pub mod docker;
 pub mod errors;

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -15,6 +15,7 @@ use std::{
     string::ToString,
     time::Duration,
 };
+use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -331,9 +332,9 @@ impl FromStr for PublishPort {
     }
 }
 
-impl ToString for PublishPort {
-    fn to_string(&self) -> String {
-        format!("{}/{}", self.port, self.protocol.as_ref())
+impl Display for PublishPort {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.port, self.protocol.as_ref())
     }
 }
 
@@ -388,15 +389,16 @@ pub enum IpcMode {
     Host,
 }
 
-impl ToString for IpcMode {
-    fn to_string(&self) -> String {
-        match &self {
+impl Display for IpcMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match &self {
             IpcMode::None => String::from("none"),
             IpcMode::Private => String::from("private"),
             IpcMode::Shareable => String::from("shareable"),
             IpcMode::Container(id) => format!("container:{}", id),
             IpcMode::Host => String::from("host"),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 
@@ -408,12 +410,13 @@ pub enum PidMode {
     Host,
 }
 
-impl ToString for PidMode {
-    fn to_string(&self) -> String {
-        match &self {
+impl Display for PidMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match &self {
             PidMode::Container(id) => format!("container:{}", id),
             PidMode::Host => String::from("host"),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -527,7 +527,7 @@ impl ContainerCreateOptsBuilder {
     impl_field!(
         /// Mount the container's root filesystem as read only.
         readonly_rootfs: bool => "HostConfig.ReadonlyRootfs"
-    );  
+    );
 
     impl_vec_field!(
         /// Specify any bind mounts, taking the form of `/some/host/path:/some/container/path`
@@ -862,6 +862,13 @@ mod tests {
                 .auto_remove(true)
                 .privileged(true),
             r#"{"HostConfig":{"AutoRemove":true,"NetworkMode":"host","Privileged":true},"Image":"test_image"}"#
+        );
+
+        test_case!(
+            ContainerCreateOptsBuilder::default()
+                .image("test_image")
+                .readonly_rootfs(true),
+            r#"{"HostConfig":{"ReadonlyRootfs":true},"Image":"test_image"}"#
         );
 
         test_case!(

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -524,6 +524,11 @@ impl ContainerCreateOptsBuilder {
         security_options => "HostConfig.SecurityOpt"
     );
 
+    impl_field!(
+        /// Mount the container's root filesystem as read only.
+        readonly_rootfs: bool => "HostConfig.ReadonlyRootfs"
+    );  
+
     impl_vec_field!(
         /// Specify any bind mounts, taking the form of `/some/host/path:/some/container/path`
         volumes => "HostConfig.Binds"

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -6,6 +6,7 @@ use containers_api::{
     impl_str_field, impl_url_bool_field, impl_url_str_field, impl_vec_field,
 };
 
+use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::{
     collections::HashMap,
@@ -15,7 +16,6 @@ use std::{
     string::ToString,
     time::Duration,
 };
-use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};

--- a/src/opts/image.rs
+++ b/src/opts/image.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
     string::ToString,
 };
+use std::fmt::Display;
 
 use containers_api::opts::{Filter, FilterItem};
 use containers_api::url::encoded_pairs;
@@ -370,16 +371,17 @@ pub enum ImageName {
     Digest { image: String, digest: String },
 }
 
-impl ToString for ImageName {
-    fn to_string(&self) -> String {
-        match &self {
+impl Display for ImageName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match &self {
             ImageName::Tag { image, tag } => match tag {
                 Some(tag) => format!("{image}:{tag}"),
                 None => image.to_owned(),
             },
             ImageName::Id(id) => id.to_owned(),
             ImageName::Digest { image, digest } => format!("{image}@{digest}"),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 

--- a/src/opts/image.rs
+++ b/src/opts/image.rs
@@ -1,9 +1,9 @@
+use std::fmt::Display;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     string::ToString,
 };
-use std::fmt::Display;
 
 use containers_api::opts::{Filter, FilterItem};
 use containers_api::url::encoded_pairs;

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -149,7 +149,10 @@ mod tests {
         assert!(serialized.contains("tail=all"));
         assert!(serialized.contains("since=2147483647"));
 
-        let options = LogsOptsBuilder::default().n_lines(5).until(&timestamp).build();
+        let options = LogsOptsBuilder::default()
+            .n_lines(5)
+            .until(&timestamp)
+            .build();
 
         let serialized = options.serialize().unwrap();
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -129,8 +129,7 @@ mod tests {
     #[cfg(feature = "chrono")]
     #[test]
     fn logs_options() {
-        let timestamp = chrono::NaiveDateTime::from_timestamp_opt(2_147_483_647, 0);
-        let since = chrono::DateTime::<chrono::Utc>::from_utc(timestamp.unwrap(), chrono::Utc);
+        let timestamp = chrono::DateTime::from_timestamp(2_147_483_647, 0).unwrap();
 
         let options = LogsOptsBuilder::default()
             .follow(true)
@@ -138,7 +137,7 @@ mod tests {
             .stderr(true)
             .timestamps(true)
             .all()
-            .since(&since)
+            .since(&timestamp)
             .build();
 
         let serialized = options.serialize().unwrap();
@@ -150,7 +149,7 @@ mod tests {
         assert!(serialized.contains("tail=all"));
         assert!(serialized.contains("since=2147483647"));
 
-        let options = LogsOptsBuilder::default().n_lines(5).until(&since).build();
+        let options = LogsOptsBuilder::default().n_lines(5).until(&timestamp).build();
 
         let serialized = options.serialize().unwrap();
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,12 +3,12 @@
 use std::env;
 use std::path::PathBuf;
 
+#[cfg(test)]
+pub use docker_api::conn;
 pub use docker_api::{api, models, models::ImageBuildChunk, opts, Docker};
 pub use futures_util::StreamExt;
 #[cfg(test)]
 pub use futures_util::TryStreamExt;
-#[cfg(test)]
-pub use docker_api::conn;
 pub use tempfile::TempDir;
 
 pub const DEFAULT_IMAGE: &str = "ubuntu:latest";

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,8 +3,12 @@
 use std::env;
 use std::path::PathBuf;
 
-pub use docker_api::{api, conn, models, models::ImageBuildChunk, opts, Docker};
-pub use futures_util::{StreamExt, TryStreamExt};
+pub use docker_api::{api, models, models::ImageBuildChunk, opts, Docker};
+pub use futures_util::StreamExt;
+#[cfg(test)]
+pub use futures_util::TryStreamExt;
+#[cfg(test)]
+pub use docker_api::conn;
 pub use tempfile::TempDir;
 
 pub const DEFAULT_IMAGE: &str = "ubuntu:latest";

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -677,12 +677,11 @@ async fn container_attach() {
     let _ = container.start().await;
 
     let mut multiplexer = container.attach().await.unwrap();
-    while let Some(chunk) = multiplexer.next().await {
+    if let Some(chunk) = multiplexer.next().await {
         match chunk {
             Ok(TtyChunk::StdOut(chunk)) => {
                 let logs = String::from_utf8_lossy(&chunk);
                 assert_eq!(logs, "123456\r\n");
-                break;
             }
             chunk => {
                 eprintln!("invalid chunk {chunk:?}");
@@ -713,12 +712,11 @@ async fn container_attach() {
     let _ = container.start().await;
 
     let mut multiplexer = container.attach().await.unwrap();
-    while let Some(chunk) = multiplexer.next().await {
+    if let Some(chunk) = multiplexer.next().await {
         match chunk {
             Ok(TtyChunk::StdOut(chunk)) => {
                 let logs = String::from_utf8_lossy(&chunk);
                 assert_eq!(logs, "123456\n");
-                break;
             }
             chunk => {
                 eprintln!("invalid chunk {chunk:?}");

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -508,7 +508,9 @@ async fn container_top() {
 
     let top_result = container.top(None).await;
     assert!(top_result.is_ok());
-    assert!(top_result.unwrap().processes.unwrap_or_default()[0][0].contains(&DEFAULT_CMD.to_string()));
+    assert!(
+        top_result.unwrap().processes.unwrap_or_default()[0][0].contains(&DEFAULT_CMD.to_string())
+    );
 
     cleanup_container(&docker, container_name).await;
 }

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -501,6 +501,13 @@ async fn container_stats() {
 async fn container_top() {
     let docker = init_runtime();
 
+    let version = docker.version().await.unwrap();
+    let is_podman = version
+        .components
+        .unwrap_or_default()
+        .iter()
+        .any(|component| component.name == "Podman Engine");
+
     let container_name = "test-top-container";
     let container = create_base_container(&docker, container_name, None).await;
 
@@ -508,9 +515,15 @@ async fn container_top() {
 
     let top_result = container.top(None).await;
     assert!(top_result.is_ok());
-    assert!(
-        top_result.unwrap().processes.unwrap_or_default()[0].contains(&DEFAULT_CMD.to_string())
-    );
+
+    if is_podman {
+        assert!(top_result.unwrap().processes.unwrap_or_default()[0][0]
+            .contains(&DEFAULT_CMD.to_string()));
+    } else {
+        assert!(
+            top_result.unwrap().processes.unwrap_or_default()[0].contains(&DEFAULT_CMD.to_string())
+        );
+    }
 
     cleanup_container(&docker, container_name).await;
 }

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -508,7 +508,7 @@ async fn container_top() {
 
     let top_result = container.top(None).await;
     assert!(top_result.is_ok());
-    assert!(top_result.unwrap().processes.unwrap_or_default()[0].contains(&DEFAULT_CMD.to_string()));
+    assert!(top_result.unwrap().processes.unwrap_or_default()[0][0].contains(&DEFAULT_CMD.to_string()));
 
     cleanup_container(&docker, container_name).await;
 }

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -691,7 +691,7 @@ async fn container_attach() {
 
     let _ = container.start().await;
 
-    let mut multiplexer = container.attach().await.unwrap();
+    let mut multiplexer = container.attach(false).await.unwrap();
     if let Some(chunk) = multiplexer.next().await {
         match chunk {
             Ok(TtyChunk::StdOut(chunk)) => {
@@ -726,7 +726,7 @@ async fn container_attach() {
 
     let _ = container.start().await;
 
-    let mut multiplexer = container.attach().await.unwrap();
+    let mut multiplexer = container.attach(false).await.unwrap();
     if let Some(chunk) = multiplexer.next().await {
         match chunk {
             Ok(TtyChunk::StdOut(chunk)) => {

--- a/tests/container_tests.rs
+++ b/tests/container_tests.rs
@@ -509,7 +509,7 @@ async fn container_top() {
     let top_result = container.top(None).await;
     assert!(top_result.is_ok());
     assert!(
-        top_result.unwrap().processes.unwrap_or_default()[0][0].contains(&DEFAULT_CMD.to_string())
+        top_result.unwrap().processes.unwrap_or_default()[0].contains(&DEFAULT_CMD.to_string())
     );
 
     cleanup_container(&docker, container_name).await;

--- a/tests/docker_tests.rs
+++ b/tests/docker_tests.rs
@@ -16,10 +16,7 @@ async fn docker_info() {
         _ => gethostname::gethostname().into_string().unwrap(),
     };
 
-    assert_eq!(
-        info_data.name.unwrap(),
-        hostname
-    );
+    assert_eq!(info_data.name.unwrap(), hostname);
 }
 
 #[tokio::test]

--- a/tests/docker_tests.rs
+++ b/tests/docker_tests.rs
@@ -9,14 +9,6 @@ async fn docker_info() {
 
     let info_result = docker.info().await;
     assert!(info_result.is_ok());
-    let info_data = info_result.unwrap();
-
-    let hostname = match info_data.default_runtime {
-        Some(runtime) if runtime == "crun" => "localhost.localdomain".to_string(),
-        _ => gethostname::gethostname().into_string().unwrap(),
-    };
-
-    assert_eq!(info_data.name.unwrap(), hostname);
 }
 
 #[tokio::test]

--- a/tests/docker_tests.rs
+++ b/tests/docker_tests.rs
@@ -10,9 +10,15 @@ async fn docker_info() {
     let info_result = docker.info().await;
     assert!(info_result.is_ok());
     let info_data = info_result.unwrap();
+
+    let hostname = match info_data.default_runtime {
+        Some(runtime) if runtime == "crun" => "localhost.localdomain".to_string(),
+        _ => gethostname::gethostname().into_string().unwrap(),
+    };
+
     assert_eq!(
         info_data.name.unwrap(),
-        gethostname::gethostname().into_string().unwrap()
+        hostname
     );
 }
 

--- a/tests/image_tests.rs
+++ b/tests/image_tests.rs
@@ -92,7 +92,8 @@ async fn image_tag() {
         .expect("image inspect data")
         .repo_tags
         .expect("repo tags")
-        .iter().any(|tag| tag.contains(&new_tag)));
+        .iter()
+        .any(|tag| tag.contains(&new_tag)));
 
     //cleanup
     let _ = image.delete().await;

--- a/tests/image_tests.rs
+++ b/tests/image_tests.rs
@@ -2,8 +2,10 @@ mod common;
 
 use common::{
     create_base_image, get_image_full_id, init_runtime, opts, tempdir_with_dockerfile, StreamExt,
-    TryStreamExt, DEFAULT_IMAGE,
+    DEFAULT_IMAGE,
 };
+
+use futures_util::TryStreamExt;
 
 #[tokio::test]
 async fn image_create_inspect_delete() {
@@ -41,7 +43,8 @@ async fn image_inspect() {
         .repo_tags
         .as_ref()
         .unwrap()
-        .contains(&format!("{image_name}:latest")));
+        .iter()
+        .any(|tag| tag.contains(&format!("{image_name}:latest"))));
     assert!(image.delete().await.is_ok());
 }
 
@@ -61,7 +64,7 @@ async fn image_history() {
     println!("{history_data:#?}");
     assert!(history_data
         .iter()
-        .any(|item| item.tags.iter().any(|t| t == DEFAULT_IMAGE)));
+        .any(|item| item.tags.iter().any(|t| t.contains(DEFAULT_IMAGE))));
 }
 
 #[tokio::test]
@@ -89,7 +92,7 @@ async fn image_tag() {
         .expect("image inspect data")
         .repo_tags
         .expect("repo tags")
-        .contains(&new_tag));
+        .iter().any(|tag| tag.contains(&new_tag)));
 
     //cleanup
     let _ = image.delete().await;

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -187,8 +187,7 @@ async fn network_connect_disconnect() {
         .unwrap()
         .networks
         .unwrap()
-        .get(network_name)
-        .is_some());
+        .contains_key(network_name));
 
     let _ = network.delete().await;
     let _ = container.delete().await;


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

I've implemented the Docker API call to resize the TTY and the readonly_rootfs flag that allows mounting the rootfs of a Container read-only.

Closes: #47 

## How did you verify your change:

I've had to manually verify the resize API call working and added a test for readonly_rootfs flag.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

- Add support for resizing the TTY
- Add support for read-only rootfs flag
- Add support for Podman in tests