### PR TITLE
feat: image build args

### DIFF
--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -89,7 +89,7 @@ impl Image {
         let headers = opts
             .auth_header()
             .map(|auth| Headers::single(AUTH_HEADER, auth))
-            .unwrap_or_else(Headers::default);
+            .unwrap_or_default();
 
         self.docker
             .post_string(&ep, Payload::empty(), Some(headers))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,7 +28,7 @@ pub mod swarm;
 #[cfg_attr(docsrs, doc(cfg(feature = "swarm")))]
 pub mod task;
 
-pub use {container::*, exec::*, image::*, network::*, system::*, volume::*};
+pub use {container::*, exec::*, image::*, network::*, volume::*};
 
 #[cfg(feature = "swarm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "swarm")))]

--- a/src/opts/image.rs
+++ b/src/opts/image.rs
@@ -314,7 +314,10 @@ impl ImageBuildOptsBuilder {
         cpu_quota: usize => "cpuquota"
     );
 
-    // TODO: buildargs
+    impl_map_field!(url
+        /// Set build-time variables.
+        build_args => "buildargs"
+    );
 
     impl_url_field!(
         /// Size of /dev/shm in bytes. The size must be greater than 0. If omitted the system uses 64MB.


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
- Adds support for `buildargs` argument when building an image. This is exposed on the `ImageBuildOpts` builder as `build_args()`.
- The default test `Dockerfile` content has been appended with an `ARG` which is used in tests.
- Minor boyscouting (fixed a few warnings).

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #72

## How did you verify your change:
New test: `image_create_with_build_args()`.
Also tested within my local app where I need this and it worked just fine.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
It's just a minor feature, but maybe good to add that it now works? (was a `TODO` previously).