### PR TITLE
implement healthcheck for ContainerCreateOptsBuilder

### DIFF
--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -902,10 +902,10 @@ mod tests {
             ContainerCreateOptsBuilder::default()
                 .image("test_image")
                 .healthcheck(HealthConfig {
-                    interval: Some(30),
-                    timeout: Some(5),
+                    interval: Some(1000000),
+                    timeout: Some(5000000),
                     retries: Some(3),
-                    start_period: Some(10),
+                    start_period: Some(10000000),
                     test: Some(vec![String::from("CMD-SHELL"), String::from("echo hello")]),
                 }),
             r#"{"Healthcheck":{"Interval":30,"Retries":3,"StartPeriod":10,"Test":["CMD-SHELL","echo hello"],"Timeout":5},"HostConfig":{},"Image":"test_image"}"#

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -901,7 +901,7 @@ mod tests {
         test_case!(
             ContainerCreateOptsBuilder::default()
                 .image("test_image")
-                .healthcheck(HealthConfig{
+                .healthcheck(HealthConfig {
                     interval: Some(30),
                     timeout: Some(5),
                     retries: Some(3),

--- a/src/opts/container.rs
+++ b/src/opts/container.rs
@@ -1,4 +1,4 @@
-use crate::models::{DeviceRequest, Labels, NetworkingConfig};
+use crate::models::{DeviceRequest, HealthConfig, Labels, NetworkingConfig};
 use crate::opts::ImageName;
 use containers_api::opts::{Filter, FilterItem};
 use containers_api::{
@@ -509,6 +509,11 @@ impl ContainerCreateOptsBuilder {
         self
     }
 
+    pub fn healthcheck(mut self, health_config: HealthConfig) -> Self {
+        self.params.insert("Healthcheck", json!(health_config));
+        self
+    }
+
     impl_str_field!(
         /// Specify the working dir (corresponds to the `-w` docker cli argument)
         working_dir => "WorkingDir"
@@ -891,6 +896,19 @@ mod tests {
                     "[::1]:8080".parse::<SocketAddr>().unwrap()
                 ),
             r#"{"ExposedPorts":{"80/tcp":{}},"HostConfig":{"PortBindings":{"80/tcp":[{"HostIp":"::1","HostPort":"8080"}]}},"Image":"test_image"}"#
+        );
+
+        test_case!(
+            ContainerCreateOptsBuilder::default()
+                .image("test_image")
+                .healthcheck(HealthConfig{
+                    interval: Some(30),
+                    timeout: Some(5),
+                    retries: Some(3),
+                    start_period: Some(10),
+                    test: Some(vec![String::from("CMD-SHELL"), String::from("echo hello")]),
+                }),
+            r#"{"Healthcheck":{"Interval":30,"Retries":3,"StartPeriod":10,"Test":["CMD-SHELL","echo hello"],"Timeout":5},"HostConfig":{},"Image":"test_image"}"#
         );
 
         test_case!(


### PR DESCRIPTION

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please run `make fmt` or `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
`ContainerCreateOptsBuilder` now has an implementation method for healthcheck.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:
I ran a container locally to verify that the healthcheck represented the config options I passed in.

<img width="1305" alt="Screenshot 2025-05-19 at 3 15 25 PM" src="https://github.com/user-attachments/assets/81953e1d-9f5c-45ec-805a-0dcb4bbed642" />



## What (if anything) would need to be called out in the CHANGELOG for the next release:
healthcheck can now be configured using the CreateContainerOptsBuilder